### PR TITLE
feat: Add Laravel 13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 Drop-in Blog module for Laravel using Nova as an admin panel.
 
 ## Requirements
-- PHP 7.3+
-- Laravel 7.x
-- Laravel Nova 3.x
-- TailwindCSS 1.6+
-- TailwindUI 0.4+
-- Tailwind Typography 0.2+
+- PHP 8.2+
+- Laravel 10.x, 11.x, 12.x, or 13.x
+- Laravel Nova 4.x or 5.x
+
+## Version Support
+
+| Laravel | Package |
+|---------|---------|
+| 10.x   | ✅      |
+| 11.x   | ✅      |
+| 12.x   | ✅      |
+| 13.x   | ✅      |
 
 ## Compatible Plugins
 - Laravel Governor

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "genealabs/laravel-nova-morph-many-to-one": "dev-master",
         "genealabs/laravel-overridable-model": "*",
         "genealabs/nova-file-upload-field": "*",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "jenssegers/model": "^1.5",
         "laravel/nova": "^4.0|^5.0",
-        "laravel/scout": "^10.0|^11.0|^12.0",
+        "laravel/scout": "^10.0|^11.0|^12.0|^13.0",
         "saumini/count": "*",
         "symfony/thanks": "^1.2"
     },

--- a/src/Post.php
+++ b/src/Post.php
@@ -18,8 +18,8 @@ class Post extends Model implements OverridableModel
     use SoftDeletes;
     use Sluggable;
 
-    protected $dates = [
-        "published_at",
+    protected $casts = [
+        "published_at" => "datetime",
     ];
     protected $fillable = [
         "excerpt",


### PR DESCRIPTION
Fixes: #2

## Changes

- Updated `illuminate/support` version constraint from `^10.0|^11.0|^12.0` to `^10.0|^11.0|^12.0|^13.0`
- Updated `laravel/scout` version constraint from `^10.0|^11.0|^12.0` to `^10.0|^11.0|^12.0|^13.0`
- Replaced deprecated `$dates` property with `$casts` in `Post` model for forward compatibility
- Updated README requirements and added version support table

## Laravel 13 Breaking Changes Addressed

- **Deprecated `$dates` property removed**: Migrated to `$casts` array with `datetime` cast, which is the modern approach since Laravel 10+ and required for Laravel 13 compatibility.